### PR TITLE
Remove petId from PUT announcement endpoint

### DIFF
--- a/announcementsAPI.json
+++ b/announcementsAPI.json
@@ -400,11 +400,6 @@
             "type": "string",
             "nullable": true
           },
-          "petId": {
-            "type": "string",
-            "format": "uuid",
-            "nullable": true
-          },
           "status": {
             "$ref": "#/components/schemas/Status"
           }


### PR DESCRIPTION
As discussed among the group - petId field has been removed due to its uselessness